### PR TITLE
Also check for file_packager in libexec

### DIFF
--- a/gen-fs.rb
+++ b/gen-fs.rb
@@ -2,7 +2,10 @@
 
 file_packager = File.dirname(`which emcc`.chomp) + "/tools/file_packager"
 unless File.exist?(file_packager)
-  file_packager = "/usr/share/emscripten/tools/file_packager"
+  file_packager = File.dirname(File.dirname(File.realpath(`which emcc`.chomp))) + "/libexec/tools/file_packager"
+  unless File.exist?(file_packager)
+    file_packager = "/usr/share/emscripten/tools/file_packager"
+  end
 end
 
 files = []


### PR DESCRIPTION
I use Linuxbrew (Homebrew on Linux) and it puts the files in a slightly
different installation tree.

I had to make this change for it to be able to find the `file_packager`
tool within the emscripten distribution.